### PR TITLE
DOC: Added documentation for prefix configuration, closes #5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,66 @@ To list all the datasets in a S3 bucket one can use the command below::
 
 See the `dtool documentation <http://dtool.readthedocs.io>`_ for more detail.
 
+Path prefix and access control
+------------------------------
+
+The S3 plugin supports a configurable prefix to the path. This can be used for
+access control to the dataset. For example, configure::
+
+    {
+       "DTOOL_S3_DATASET_PREFIX_my-bucket": "u/olssont"
+    }
+
+and use the following S3 access to policy to that allows reading all data
+in the bucket but only writing to the prefix `u/<username>` and `dtool-`::
+
+    {
+      "Statement": [
+        {
+          "Sid": "AllowReadonlyAccess",
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket",
+            "s3:ListBucketVersions",
+            "s3:GetObject",
+            "s3:GetObjectTagging",
+            "s3:GetObjectVersion",
+            "s3:GetObjectVersionTagging"
+          ],
+          "Resource": [
+            "arn:aws:s3:::my-bucket",
+            "arn:aws:s3:::my-bucket/*"
+          ]
+        },
+        {
+          "Sid": "AllowPartialWriteAccess",
+          "Effect": "Allow",
+          "Action": [
+            "s3:DeleteObject",
+            "s3:PutObject",
+            "s3:PutObjectAcl"
+          ],
+          "Resource": [
+            "arn:aws:s3:::my-bucket/dtool-*",
+            "arn:aws:s3:::my-bucket/u/${aws:username}/*"
+          ]
+        },
+        {
+          "Sid": "AllowListAllBuckets",
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListAllMyBuckets",
+            "s3:GetBucketLocation"
+          ],
+          "Resource": "arn:aws:s3:::*"
+        }
+      ]
+    }
+
+The user also needs write access to toplevel objects that start with `dtool-`.
+Those are the registration keys that are not stored under the configured
+prefix. The registration keys contain the prefix where the respective dataset
+is found. They are empty if no prefix is configured.
 
 Testing
 -------
@@ -92,6 +152,8 @@ Related packages
 
 - `dtoolcore <https://github.com/jic-dtool/dtoolcore>`_
 - `dtool-cli <https://github.com/jic-dtool/dtool-cli>`_
+- `dtool-ecs <https://github.com/jic-dtool/dtool-ecs>`_
 - `dtool-http <https://github.com/jic-dtool/dtool-http>`_
 - `dtool-azure <https://github.com/jic-dtool/dtool-azure>`_
 - `dtool-irods <https://github.com/jic-dtool/dtool-irods>`_
+- `dtool-smb <https://github.com/IMTEK-Simulation/dtool-smb>`_


### PR DESCRIPTION
Hi @tjelvar-olsson - this is suggestion for the documentation that parallels what's in ECS.

Note thtat I cannot test the access policy as I don't have an AWS setup... by I believe the policy language of our NetApp StorageGRID is a subset of the AWS policy language.