### PR TITLE
Endpoint-specific dataset prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 Changed
 ^^^^^^^
 
+- Converted generic ``DTOOL_S3_DATASET_PREFIX`` config key into
+  endpoint-specific ``DTOOL_S3_DATASET_PREFIX_<BUCKET NAME>`` parameter.
 
 Deprecated
 ^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -64,14 +64,15 @@ For example::
 
 The configuration can also be done using your environment variables. For example on Linux/Mac::
 
-       export DTOOL_S3_ENDPOINT_my_bucket=http://blueberry.famous.uni.ac.uk
-       export DTOOL_S3_ACCESS_KEY_ID_my_bucket=olssont
-       export DTOOL_S3_SECRET_ACCESS_KEY_my_bucket=some-secret-token
+    env 'DTOOL_S3_ENDPOINT_my-bucket=http://blueberry.famous.uni.ac.uk' \
+        'DTOOL_S3_ACCESS_KEY_ID_my-bucket=olssont' \
+        'DTOOL_S3_SECRET_ACCESS_KEY_my_bucket=some-secret-token' bash
 
-Note that you might want to avoid hyphons in environment variable names.
-For identifying buckets, we can safely replace hyphons with underscores
-(and lowercase letters with uppercase) without introducing ambiguity according
-to the `bucket naming rules <https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html>`_.
+Note that hyphens in environment variable names do not adhere to the
+`POSIX standard <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html>`_
+``export`` will not allow such names, hence the above *workaround* via ``env`` may
+be necessary to modify the environment.
+
 
 Usage
 -----
@@ -93,7 +94,7 @@ Path prefix and access control
 The S3 plugin supports an endpoint-specific configurable prefix to the path.
 This can be used for access control to the dataset. For example::
 
-    export DTOOL_S3_DATASET_PREFIX_my_bucket=u/olssont
+    env 'DTOOL_S3_DATASET_PREFIX_my-bucket=u/olssont' bash
 
 Alternatively one can edit the ``~/.config/dtool/dtool.json`` file::
 

--- a/README.rst
+++ b/README.rst
@@ -64,10 +64,14 @@ For example::
 
 The configuration can also be done using your environment variables. For example on Linux/Mac::
 
-       export DTOOL_S3_ENDPOINT_my-bucket=http://blueberry.famous.uni.ac.uk
-       export DTOOL_S3_ACCESS_KEY_ID_my-bucket=olssont
-       export DTOOL_S3_SECRET_ACCESS_KEY_my-bucket=some-secret-token
+       export DTOOL_S3_ENDPOINT_my_bucket=http://blueberry.famous.uni.ac.uk
+       export DTOOL_S3_ACCESS_KEY_ID_my_bucket=olssont
+       export DTOOL_S3_SECRET_ACCESS_KEY_my_bucket=some-secret-token
 
+Note that you might want to avoid hyphons in environment variable names.
+For identifying buckets, we can safely replace hyphons with underscores
+(and lowercase letters with uppercase) without introducing ambiguity according
+to the `bucket naming rules <https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html>`_.
 
 Usage
 -----
@@ -86,16 +90,16 @@ See the `dtool documentation <http://dtool.readthedocs.io>`_ for more detail.
 Path prefix and access control
 ------------------------------
 
-The S3 plugin supports a configurable prefix to the path. This can be used for
-access control to the dataset. For example::
+The S3 plugin supports an endpoint-specific configurable prefix to the path.
+This can be used for access control to the dataset. For example::
 
-    export DTOOL_S3_DATASET_PREFIX="u/olssont"
+    export DTOOL_S3_DATASET_PREFIX_my_bucket=u/olssont
 
 Alternatively one can edit the ``~/.config/dtool/dtool.json`` file::
 
     {
        ...,
-       "DTOOL_S3_DATASET_PREFIX": "u/olssont"
+       "DTOOL_S3_DATASET_PREFIX_my-bucket": "u/olssont"
     }
 
 

--- a/dtool_s3/storagebroker.py
+++ b/dtool_s3/storagebroker.py
@@ -120,6 +120,55 @@ def _upload_file(s3client, fpath, bucket, dest_path, extra_args):
 
     return True
 
+def _sanitize_config_key(key):
+    """Converts lowercase to uppercase and hyphens to underscores.
+
+    :param key: name of lookup value
+    :returns: value associated with the key
+    """
+    return key.upper().replace('-','_')
+
+
+def _get_config_value_from_sanitized_key(key, config_path=None, default=None):
+    """Bucket names may consist of lowercase letters, numbers, dots and hyphens.
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    This S3 plugin offers the configuration of bucket-specific keys. For keys
+    specified within the dtool.json config file, this is fine. If specified via
+    environment variables, hyphens and lowercase characters may be an issue,
+    depending on the operating system. Thus, we check for such keys twice:
+    Once the key as passed (i.e. with the bucket name stated exactly as
+    extracted from the URI, which might match the keys in the JSON config file,
+    but might miss settings specified via environment variables), and a second
+    time with a "sanitized" key, with all lowercase letters converted to
+    uppercase and all hyphens converted to underscores. In case of a conflict,
+    i.e. differing non-zero values returned by both methods, we log a warning
+    and use the latter method's result.
+
+    :param key: name of lookup value
+    :param config_path: path to JSON configuration file
+    :param default: default fall back value
+    :returns: value associated with the key
+    """
+    sanitized_key = _sanitize_config_key(key)
+    value_from_literal_key = get_config_value(key)
+    value_from_sanitized_key = get_config_value(sanitized_key)
+
+    if (value_from_literal_key is not None) and (
+            value_from_sanitized_key is not None):
+        if value_from_sanitized_key != value_from_literal_key:
+            logger.warning(
+                "Config key '{key}' and its sanitized variant '{sanitized}' "
+                "yield different values '{value}' and '{sanitized_value}'. "
+                "Latter supersedes former."
+                .format(key=key, sanitized=sanitized_key,
+                        value=value_from_literal_key,
+                        sanitized_value=value_from_sanitized_key))
+        return value_from_sanitized_key
+    elif value_from_sanitized_key is not None:
+        return value_from_sanitized_key
+    else:
+        return value_from_literal_key
+
 
 def _put_item_with_retry(
     s3client,
@@ -205,7 +254,10 @@ class S3StorageBroker(BaseStorageBroker):
         self.bucket = parse_result.netloc
         uuid = parse_result.path[1:]
 
-        self.dataset_prefix = get_config_value("DTOOL_S3_DATASET_PREFIX")
+        self.dataset_prefix = _get_config_value_from_sanitized_key(
+            "DTOOL_S3_DATASET_PREFIX_{}".format(self.bucket)
+        )
+
         self.uuid = uuid
 
         self.s3resource, self.s3client = \
@@ -243,13 +295,13 @@ class S3StorageBroker(BaseStorageBroker):
     def _get_resource_and_client(cls, bucket_name):
         # Get S3 endpoint, access key and secret key. Can be left
         # unconfigured, in which case the AWS configuration is used.
-        s3_endpoint = get_config_value(
+        s3_endpoint = _get_config_value_from_sanitized_key(
             "DTOOL_S3_ENDPOINT_{}".format(bucket_name)
         )
-        s3_access_key_id = get_config_value(
+        s3_access_key_id = _get_config_value_from_sanitized_key(
             "DTOOL_S3_ACCESS_KEY_ID_{}".format(bucket_name)
         )
-        s3_secret_access_key = get_config_value(
+        s3_secret_access_key = _get_config_value_from_sanitized_key(
             "DTOOL_S3_SECRET_ACCESS_KEY_{}".format(bucket_name)
         )
 

--- a/dtool_s3/storagebroker.py
+++ b/dtool_s3/storagebroker.py
@@ -120,55 +120,6 @@ def _upload_file(s3client, fpath, bucket, dest_path, extra_args):
 
     return True
 
-def _sanitize_config_key(key):
-    """Converts lowercase to uppercase and hyphens to underscores.
-
-    :param key: name of lookup value
-    :returns: value associated with the key
-    """
-    return key.upper().replace('-','_')
-
-
-def _get_config_value_from_sanitized_key(key, config_path=None, default=None):
-    """Bucket names may consist of lowercase letters, numbers, dots and hyphens.
-    https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-    This S3 plugin offers the configuration of bucket-specific keys. For keys
-    specified within the dtool.json config file, this is fine. If specified via
-    environment variables, hyphens and lowercase characters may be an issue,
-    depending on the operating system. Thus, we check for such keys twice:
-    Once the key as passed (i.e. with the bucket name stated exactly as
-    extracted from the URI, which might match the keys in the JSON config file,
-    but might miss settings specified via environment variables), and a second
-    time with a "sanitized" key, with all lowercase letters converted to
-    uppercase and all hyphens converted to underscores. In case of a conflict,
-    i.e. differing non-zero values returned by both methods, we log a warning
-    and use the latter method's result.
-
-    :param key: name of lookup value
-    :param config_path: path to JSON configuration file
-    :param default: default fall back value
-    :returns: value associated with the key
-    """
-    sanitized_key = _sanitize_config_key(key)
-    value_from_literal_key = get_config_value(key)
-    value_from_sanitized_key = get_config_value(sanitized_key)
-
-    if (value_from_literal_key is not None) and (
-            value_from_sanitized_key is not None):
-        if value_from_sanitized_key != value_from_literal_key:
-            logger.warning(
-                "Config key '{key}' and its sanitized variant '{sanitized}' "
-                "yield different values '{value}' and '{sanitized_value}'. "
-                "Latter supersedes former."
-                .format(key=key, sanitized=sanitized_key,
-                        value=value_from_literal_key,
-                        sanitized_value=value_from_sanitized_key))
-        return value_from_sanitized_key
-    elif value_from_sanitized_key is not None:
-        return value_from_sanitized_key
-    else:
-        return value_from_literal_key
-
 
 def _put_item_with_retry(
     s3client,
@@ -254,9 +205,8 @@ class S3StorageBroker(BaseStorageBroker):
         self.bucket = parse_result.netloc
         uuid = parse_result.path[1:]
 
-        self.dataset_prefix = _get_config_value_from_sanitized_key(
-            "DTOOL_S3_DATASET_PREFIX_{}".format(self.bucket)
-        )
+        self.dataset_prefix = get_config_value(
+            "DTOOL_S3_DATASET_PREFIX_{}".format(self.bucket))
 
         self.uuid = uuid
 
@@ -295,13 +245,13 @@ class S3StorageBroker(BaseStorageBroker):
     def _get_resource_and_client(cls, bucket_name):
         # Get S3 endpoint, access key and secret key. Can be left
         # unconfigured, in which case the AWS configuration is used.
-        s3_endpoint = _get_config_value_from_sanitized_key(
+        s3_endpoint = get_config_value(
             "DTOOL_S3_ENDPOINT_{}".format(bucket_name)
         )
-        s3_access_key_id = _get_config_value_from_sanitized_key(
+        s3_access_key_id = get_config_value(
             "DTOOL_S3_ACCESS_KEY_ID_{}".format(bucket_name)
         )
-        s3_secret_access_key = _get_config_value_from_sanitized_key(
+        s3_secret_access_key = get_config_value(
             "DTOOL_S3_SECRET_ACCESS_KEY_{}".format(bucket_name)
         )
 

--- a/tests/test_prefix_for_storage_location_functional.py
+++ b/tests/test_prefix_for_storage_location_functional.py
@@ -15,9 +15,15 @@ def test_prefix_functional():  # NOQA
 
     from dtoolcore import DataSetCreator
     from dtoolcore import DataSet, iter_datasets_in_base_uri
+    from dtoolcore.utils import generous_parse_uri
+    from dtool_s3.storagebroker import _sanitize_config_key
+
+    parse_result = generous_parse_uri(S3_TEST_BASE_URI)
+    bucket = parse_result.netloc
+    sanitized_bucket = _sanitize_config_key(bucket)
 
     # Create a minimal dataset without a prefix
-    with tmp_env_var("DTOOL_S3_DATASET_PREFIX", ""):
+    with tmp_env_var("DTOOL_S3_DATASET_PREFIX_{}".format(sanitized_bucket), ""):
         with DataSetCreator("no-prefix", S3_TEST_BASE_URI) as ds_creator:
             ds_creator.put_annotation("prefix", "no")
             no_prefix_uri = ds_creator.uri
@@ -33,7 +39,8 @@ def test_prefix_functional():  # NOQA
 
     # Create a minimal dataset
     prefix = "u/olssont/"
-    with tmp_env_var("DTOOL_S3_DATASET_PREFIX", prefix):
+    with tmp_env_var(
+            "DTOOL_S3_DATASET_PREFIX_{}".format(sanitized_bucket), prefix):
         with DataSetCreator("no-prefix", S3_TEST_BASE_URI) as ds_creator:
             ds_creator.put_annotation("prefix", "yes")
             prefix_uri = ds_creator.uri

--- a/tests/test_prefix_for_storage_location_functional.py
+++ b/tests/test_prefix_for_storage_location_functional.py
@@ -16,14 +16,12 @@ def test_prefix_functional():  # NOQA
     from dtoolcore import DataSetCreator
     from dtoolcore import DataSet, iter_datasets_in_base_uri
     from dtoolcore.utils import generous_parse_uri
-    from dtool_s3.storagebroker import _sanitize_config_key
 
     parse_result = generous_parse_uri(S3_TEST_BASE_URI)
     bucket = parse_result.netloc
-    sanitized_bucket = _sanitize_config_key(bucket)
 
     # Create a minimal dataset without a prefix
-    with tmp_env_var("DTOOL_S3_DATASET_PREFIX_{}".format(sanitized_bucket), ""):
+    with tmp_env_var("DTOOL_S3_DATASET_PREFIX_{}".format(bucket), ""):
         with DataSetCreator("no-prefix", S3_TEST_BASE_URI) as ds_creator:
             ds_creator.put_annotation("prefix", "no")
             no_prefix_uri = ds_creator.uri
@@ -40,7 +38,7 @@ def test_prefix_functional():  # NOQA
     # Create a minimal dataset
     prefix = "u/olssont/"
     with tmp_env_var(
-            "DTOOL_S3_DATASET_PREFIX_{}".format(sanitized_bucket), prefix):
+            "DTOOL_S3_DATASET_PREFIX_{}".format(bucket), prefix):
         with DataSetCreator("no-prefix", S3_TEST_BASE_URI) as ds_creator:
             ds_creator.put_annotation("prefix", "yes")
             prefix_uri = ds_creator.uri


### PR DESCRIPTION
* Suggestion for introducing endpoint-specific DATASET_PREFIX configuration keys as found within `dtool-ecs`, in referenct o https://github.com/jic-dtool/dtool-s3/issues/11.
* Suggestion for "sanitizing" configuration keys into less problematic environment variable name, as contemplated at  https://github.com/jic-dtool/dtool-s3/pull/10#issuecomment-907783341

Note that I did not run the tests yet. I will have to set up some s3 testing environment and come back then.