### PR TITLE
Align admin_metadata types with behvior of dtoolcore.storagebroker.BaseStorageBroker

### DIFF
--- a/dtool_s3/storagebroker.py
+++ b/dtool_s3/storagebroker.py
@@ -50,16 +50,6 @@ _STRUCTURE_PARAMETERS = {
     "storage_broker_version": __version__,
 }
 
-_ADMIN_METADATA_TYPES = {
-    "created_at": float,
-    "creator_username": str,
-    "dtoolcore_version": str,
-    "frozen_at": float,
-    "name": str,
-    "type": str,
-    "uuid": str,
-}
-
 _DTOOL_README_TXT = """README
 ======
 This is a Dtool dataset stored in S3 accessible storage.
@@ -498,16 +488,11 @@ class S3StorageBroker(BaseStorageBroker):
             self.get_admin_metadata_key()
         ).get()
 
-        # All values in response['Metadata'] are of type str.
-        # This collides with the behavir of other storage brokers, in particular
-        # the default dtoolcore.storagebrokerBaseStorageBroker, which
-        # would return timestamps as floats, see
-        # https://github.com/jic-dtool/dtoolcore/blob/e976c426bef01cc9abdc985e36eae3695d8ee384/dtoolcore/storagebroker.py#L240-L244
-        # Hence, convert as desired:
         admin_metadata = response['Metadata']
-        for key, desired_type in _ADMIN_METADATA_TYPES.items():
-            if key in admin_metadata and not isinstance(admin_metadata[key], desired_type):
-                admin_metadata[key] = desired_type(admin_metadata[key])
+        # s3-native metadata comes as str only, convert timestamps back to float:
+        admin_metadata["frozen_at"] = float(admin_metadata["frozen_at"])
+        if "created_at" in admin_metadata:
+            admin_metadata["created_at"] = float(admin_metadata["created_at"])
         return admin_metadata
 
     def get_size_in_bytes(self, handle):

--- a/dtool_s3/storagebroker.py
+++ b/dtool_s3/storagebroker.py
@@ -50,6 +50,16 @@ _STRUCTURE_PARAMETERS = {
     "storage_broker_version": __version__,
 }
 
+_ADMIN_METADATA_TYPES = {
+    "created_at": float,
+    "creator_username": str,
+    "dtoolcore_version": str,
+    "frozen_at": float,
+    "name": str,
+    "type": str,
+    "uuid": str,
+}
+
 _DTOOL_README_TXT = """README
 ======
 This is a Dtool dataset stored in S3 accessible storage.
@@ -488,7 +498,17 @@ class S3StorageBroker(BaseStorageBroker):
             self.get_admin_metadata_key()
         ).get()
 
-        return response['Metadata']
+        # All values in response['Metadata'] are of type str.
+        # This collides with the behavir of other storage brokers, in particular
+        # the default dtoolcore.storagebrokerBaseStorageBroker, which
+        # would return timestamps as floats, see
+        # https://github.com/jic-dtool/dtoolcore/blob/e976c426bef01cc9abdc985e36eae3695d8ee384/dtoolcore/storagebroker.py#L240-L244
+        # Hence, convert as desired:
+        admin_metadata = response['Metadata']
+        for key, desired_type in _ADMIN_METADATA_TYPES.items():
+            if key in admin_metadata and not isinstance(admin_metadata[key], desired_type):
+                admin_metadata[key] = desired_type(admin_metadata[key])
+        return admin_metadata
 
     def get_size_in_bytes(self, handle):
         logger.debug("Get size in bytes {}".format(self))


### PR DESCRIPTION
In the default behavior of  `BaseStorageBroker`, metadata values are evaluated as JSON when read via [get_admin_metadata](https://github.com/jic-dtool/dtoolcore/blob/e976c426bef01cc9abdc985e36eae3695d8ee384/dtoolcore/storagebroker.py#L240-L244). This returns the timestamp fields `created_at` and `frozen_at` as floats. The s3 storage broker 
https://github.com/jic-dtool/dtool-s3/blob/b0b98c9200865ba263d3a1db55b78cc844717935/dtool_s3/storagebroker.py#L483-L491
deviates from this behavior and returns the metadata object as retrieved via boto3. This apparently may yield the timestamp fields as strings, see below comparison between s3 and other storage broker.

```python
>>> import dtoolcore
>>> from dtool_cli.cli import (
...     CONFIG_PATH,
... )
>>> smb_admin_metadata = dtoolcore._admin_metadata_from_uri('smb://jh1130/001b8a13-3db5-4e0a-bb19-d8e6a8a44ad6', CONFIG_PATH)
>>> smb_admin_metadata
{'uuid': '001b8a13-3db5-4e0a-bb19-d8e6a8a44ad6', 'dtoolcore_version': '3.17.0', 'name': '2020-09-14-19-40-26-128617-n-844-m-844-s-monolayer-substratepassivation', 'type': 'dataset', 'creator_username': 'hoermann4', 'created_at': 1600120598.214282, 'frozen_at': 1600831276.888873}
>>> s3_admin_metadata = dtoolcore._admin_metadata_from_uri('s3://frct-simdata/001b8a13-3db5-4e0a-bb19-d8e6a8a44ad6', CONFIG_PATH)
>>> s3_admin_metadata
{'created_at': '1600120598.214282', 'creator_username': 'hoermann4', 'dtoolcore_version': '3.17.0', 'frozen_at': '1600831276.888873', 'name': '2020-09-14-19-40-26-128617-n-844-m-844-s-monolayer-substratepassivation', 'type': 'dataset', 'uuid': '001b8a13-3db5-4e0a-bb19-d8e6a8a44ad6'}
>>> type(smb_admin_metadata['frozen_at'])
<class 'float'>
>>> type(s3_admin_metadata['frozen_at'])
<class 'str'>
```

This PR aligns the behavior to the dtoolcore reference implementation.